### PR TITLE
Added Binary Stream UInt32 ReadWrite Unit Test

### DIFF
--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsUInt32.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsUInt32.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsUInt32
+    {
+    // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteUInt32()
+        {
+            UInt32[] values = new UInt32[] { 0, 0xFFFFFFFF, 0x0000000F, 0xF0000000, 0x10AB8700 };
+
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+                foreach (UInt32 value in values)
+                    binaryStream.WriteUInt32(value);
+                foreach (UInt32 value in values)
+                    binaryStream.WriteUInt32(value, ByteConverter.Big);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (UInt32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt32());
+                foreach (UInt32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt32(ByteConverter.Big));
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadUInt32s(values.Length));
+                CollectionAssert.AreEqual(values, binaryStream.ReadUInt32s(values.Length, ByteConverter.Big));
+            }
+        }
+    }
+} 


### PR DESCRIPTION
-Created BinaryStreamTestsUInt32.cs class for UInt32 specific BinaryStream tests.
-Added ReadWriteUInt32() Unit Test to demonstrate the read and write functions in both little and bit endian.

I have created a unit test for reading and writing UInt32 values with the Binary Stream. I based it off the unit test for UInt32 values with StreamExtensions to keep the tests consistent. This one has a bit more to it than the previous Seek unit test I added. 

Let me know if you have any feedback or issues with how I have set this test up. If it all checks out I would be happy to continue doing more in a similar fashion. Otherwise I can make adjustments if needed.