### PR TITLE
Added Read/Write Tests for U/Int16, Int32, Double, Single & Fix for UInt32 Test

### DIFF
--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsDouble.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsDouble.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsDouble
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteDouble()
+        {
+            Double[] values = new Double[] { 0, -1, 1, -.5, .5, 158.2905, Double.MaxValue, Double.MinValue, Double.Epsilon, Double.NaN, Double.NegativeInfinity,
+                Double.PositiveInfinity };
+
+            // Test Binary Stream with default endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+                foreach (Double value in values)
+                    binaryStream.WriteDouble(value);
+                foreach (Double value in values)
+                    binaryStream.WriteDouble(value, ByteConverter.Big);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble());
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble(ByteConverter.Big));
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadDoubles(values.Length));
+                CollectionAssert.AreEqual(values, binaryStream.ReadDoubles(values.Length, ByteConverter.Big));
+
+                // Confirm system endian is initialized by default
+                binaryStream.Position = 0;
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble(ByteConverter.System));
+            }
+
+            // Test Binary Stream with big endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Big))
+            {
+                // Prepare test data.
+                foreach (Double value in values)
+                    binaryStream.WriteDouble(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadDoubles(values.Length));
+
+                // Confirm read and write calls are using big endian.
+                binaryStream.Position = 0;
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble(ByteConverter.Big));
+            }
+
+            // Test Binary Stream with little endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Little))
+            {
+                // Prepare test data.
+                foreach (Double value in values)
+                    binaryStream.WriteDouble(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadDoubles(values.Length));
+
+                // Confirm read and write calls are using little endian.
+                binaryStream.Position = 0;
+                foreach (Double value in values)
+                    Assert.AreEqual(value, binaryStream.ReadDouble(ByteConverter.Little));
+            }
+        }
+    }
+}

--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsInt16.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsInt16.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsInt16
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteInt16()
+        {
+            Int16[] values = new Int16[] { 0, Int16.MaxValue, Int16.MinValue, 0x0001, 0x1000, 0x10AB };
+
+            // Test Binary Stream with default endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+                foreach (Int16 value in values)
+                    binaryStream.WriteInt16(value);
+                foreach (Int16 value in values)
+                    binaryStream.WriteInt16(value, ByteConverter.Big);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16());
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16(ByteConverter.Big));
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt16s(values.Length));
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt16s(values.Length, ByteConverter.Big));
+
+                // Confirm system endian is initialized by default
+                binaryStream.Position = 0;
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16(ByteConverter.System));
+            }
+
+            // Test Binary Stream with big endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Big))
+            {
+                // Prepare test data.
+                foreach (Int16 value in values)
+                    binaryStream.WriteInt16(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt16s(values.Length));
+
+                // Confirm read and write calls are using big endian.
+                binaryStream.Position = 0;
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16(ByteConverter.Big));
+            }
+
+            // Test Binary Stream with little endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Little))
+            {
+                // Prepare test data.
+                foreach (Int16 value in values)
+                    binaryStream.WriteInt16(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt16s(values.Length));
+
+                // Confirm read and write calls are using little endian.
+                binaryStream.Position = 0;
+                foreach (Int16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt16(ByteConverter.Little));
+            }
+        }
+    }
+}

--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsInt32.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsInt32.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsInt32
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteInt32()
+        {
+            Int32[] values = new Int32[] { 0, Int32.MaxValue, Int32.MinValue, 0x00000001, 0x10000000, 0x10AB8700 };
+
+            // Test Binary Stream with default endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+                foreach (Int32 value in values)
+                    binaryStream.WriteInt32(value);
+                foreach (Int32 value in values)
+                    binaryStream.WriteInt32(value, ByteConverter.Big);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32());
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32(ByteConverter.Big));
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt32s(values.Length));
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt32s(values.Length, ByteConverter.Big));
+
+                // Confirm system endian is initialized by default
+                binaryStream.Position = 0;
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32(ByteConverter.System));
+            }
+
+            // Test Binary Stream with big endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Big))
+            {
+                // Prepare test data.
+                foreach (Int32 value in values)
+                    binaryStream.WriteInt32(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt32s(values.Length));
+
+                // Confirm read and write calls are using big endian.
+                binaryStream.Position = 0;
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32(ByteConverter.Big));
+            }
+
+            // Test Binary Stream with little endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Little))
+            {
+                // Prepare test data.
+                foreach (Int32 value in values)
+                    binaryStream.WriteInt32(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadInt32s(values.Length));
+
+                // Confirm read and write calls are using little endian.
+                binaryStream.Position = 0;
+                foreach (Int32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadInt32(ByteConverter.Little));
+            }
+        }
+    }
+}

--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsSingle.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsSingle.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsSingle
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteSingle()
+        {
+            Single[] values = new Single[] { 0, -1, 1, -.5f, .5f, 158.2905f, Single.MaxValue, Single.MinValue, Single.Epsilon, Single.NaN, Single.NegativeInfinity,
+                Single.PositiveInfinity };
+
+            // Test Binary Stream with default endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+                foreach (Single value in values)
+                    binaryStream.WriteSingle(value);
+                foreach (Single value in values)
+                    binaryStream.WriteSingle(value, ByteConverter.Big);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle());
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle(ByteConverter.Big));
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadSingles(values.Length));
+                CollectionAssert.AreEqual(values, binaryStream.ReadSingles(values.Length, ByteConverter.Big));
+
+                // Confirm system endian is initialized by default
+                binaryStream.Position = 0;
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle(ByteConverter.System));
+            }
+
+            // Test Binary Stream with big endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Big))
+            {
+                // Prepare test data.
+                foreach (Single value in values)
+                    binaryStream.WriteSingle(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadSingles(values.Length));
+
+                // Confirm read and write calls are using big endian.
+                binaryStream.Position = 0;
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle(ByteConverter.Big));
+            }
+
+            // Test Binary Stream with little endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Little))
+            {
+                // Prepare test data.
+                foreach (Single value in values)
+                    binaryStream.WriteSingle(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadSingles(values.Length));
+
+                // Confirm read and write calls are using little endian.
+                binaryStream.Position = 0;
+                foreach (Single value in values)
+                    Assert.AreEqual(value, binaryStream.ReadSingle(ByteConverter.Little));
+            }
+        }
+    }
+}

--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsUInt16.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsUInt16.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsUInt16
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteUInt16()
+        {
+            UInt16[] values = new UInt16[] { 0x10AB, 0xFFFF, 0x000F, 0xF000, 0 };
+
+            // Test Binary Stream with default endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+                foreach (UInt16 value in values)
+                    binaryStream.WriteUInt16(value);
+                foreach (UInt16 value in values)
+                    binaryStream.WriteUInt16(value, ByteConverter.Big);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16());
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16(ByteConverter.Big));
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadUInt16s(values.Length));
+                CollectionAssert.AreEqual(values, binaryStream.ReadUInt16s(values.Length, ByteConverter.Big));
+
+                // Confirm system endian is initialized by default
+                binaryStream.Position = 0;
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16(ByteConverter.System));
+            }
+
+            // Test Binary Stream with big endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Big))
+            {
+                // Prepare test data.
+                foreach (UInt16 value in values)
+                    binaryStream.WriteUInt16(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadUInt16s(values.Length));
+
+                // Confirm read and write calls are using big endian.
+                binaryStream.Position = 0;
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16(ByteConverter.Big));
+            }
+
+            // Test Binary Stream with little endian initialization.
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream, ByteConverter.Little))
+            {
+                // Prepare test data.
+                foreach (UInt16 value in values)
+                    binaryStream.WriteUInt16(value);
+
+                // Read test data.
+                binaryStream.Position = 0;
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16());
+
+                // Read test data all at once. 
+                binaryStream.Position = 0;
+                CollectionAssert.AreEqual(values, binaryStream.ReadUInt16s(values.Length));
+
+                // Confirm read and write calls are using little endian.
+                binaryStream.Position = 0;
+                foreach (UInt16 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt16(ByteConverter.Little));
+            }
+        }
+    }
+}

--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsUInt32.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsUInt32.cs
@@ -36,9 +36,10 @@ namespace Syroot.BinaryData.UnitTest
                 CollectionAssert.AreEqual(values, binaryStream.ReadUInt32s(values.Length));
                 CollectionAssert.AreEqual(values, binaryStream.ReadUInt32s(values.Length, ByteConverter.Big));
 
-                // Confirm Little endian is initialized by default
+                // Confirm system endian is initialized by default
                 binaryStream.Position = 0;
-                Assert.AreEqual(values[0], binaryStream.ReadUInt32(ByteConverter.Little));
+                foreach (UInt32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt32(ByteConverter.System));
             }
 
             // Test Binary Stream with big endian initialization.
@@ -60,7 +61,8 @@ namespace Syroot.BinaryData.UnitTest
 
                 // Confirm read and write calls are using big endian.
                 binaryStream.Position = 0;
-                Assert.AreEqual(values[0], binaryStream.ReadUInt32(ByteConverter.Big));
+                foreach (UInt32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt32(ByteConverter.Big));
             }
 
             // Test Binary Stream with little endian initialization.
@@ -82,7 +84,8 @@ namespace Syroot.BinaryData.UnitTest
 
                 // Confirm read and write calls are using little endian.
                 binaryStream.Position = 0;
-                Assert.AreEqual(values[0], binaryStream.ReadUInt32(ByteConverter.Little));
+                foreach (UInt32 value in values)
+                    Assert.AreEqual(value, binaryStream.ReadUInt32(ByteConverter.Little));
             }
         }
     }


### PR DESCRIPTION
To start off: I have fixed an issue with the UInt32 Read/Write test I added. After adding tests for when supplying the BinaryStream an endianness setting I also added a check to the default BinaryStream to confirm the endianness it selected. There were two problems with this check.

1. I made an incorrect assumption that the default endianness would be little endian. After checking with the source file for the BinaryStream I saw that it's actual functionality was to set to the system's endianness. I have modified this endianness check to ensure that it is set to the system's endianness instead.

2. The second issue was that to keep the test brief and simple, I had it check the first value of the values array. This meant that if the first value was 0 for example, the test would pass regardless of the endianness setting. I have changed it to check the whole array to avoid this issue. It is more thorough this way.

With those two flaws solved, I have also added this Read/Write test for Int32, Int16, UInt16, Single, and Double value types.