### PR TITLE
Expanded Binary Stream Seek Unit Test

### DIFF
--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTests.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTests.cs
@@ -15,14 +15,40 @@ namespace Syroot.BinaryData.UnitTest
             using (MemoryStream stream = new MemoryStream())
             using (BinaryStream binaryStream = new BinaryStream(stream))
             {
+                // Prepare stream by writing data.
+                binaryStream.WriteUInt32(0xFFFFFFFF);
+
+                // Check that the stream position can be set from the Beginning of the stream.
+                binaryStream.Seek(0, SeekOrigin.Begin);
                 Assert.AreEqual(0, binaryStream.Position);
 
-                stream.Seek(2);
+                // Check that the stream can seek forwards.
+                binaryStream.Seek(2);
                 Assert.AreEqual(2, binaryStream.Position);
 
-                stream.Seek(2);
-                Assert.AreEqual(4, binaryStream.Position);
+                // Check that the stream can seek backwards.
+                binaryStream.Seek(-2);
+                Assert.AreEqual(0, binaryStream.Position);
+
+                // Check that the stream can seek forwards from the current origin.
+                binaryStream.Seek(2, SeekOrigin.Current);
+                Assert.AreEqual(2, binaryStream.Position);
+
+                // Check that the stream can seek to End of the stream.
+                binaryStream.Seek(0, SeekOrigin.End);
+                Assert.AreEqual(binaryStream.Length, binaryStream.Position);
+
+                // Check that the stream can seek backwards from the end of the stream.
+                binaryStream.Seek(-2, SeekOrigin.End);
+                Assert.AreEqual(binaryStream.Length - 2, binaryStream.Position);
+
+                // Check that the stream can seek forwards from the beginning origin.
+                binaryStream.Seek(2, SeekOrigin.Begin);
+                Assert.AreEqual(2, binaryStream.Position);
+
             }
+
+
         }
 
     }


### PR DESCRIPTION
I have added a number of extra checks. This test now checks negative seeking in addition to seeking from different origins.