### PR TITLE
Added Read/Write Unit Test for Boolean Values

### DIFF
--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsBoolean.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsBoolean.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsBoolean
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteBoolean()
+        {
+            Boolean[] values = new Boolean[] { true, false };
+            BooleanCoding[] encodings = new BooleanCoding[] { BooleanCoding.Byte, BooleanCoding.Word, BooleanCoding.Dword };
+            ByteConverter[] endianness = new ByteConverter[] { ByteConverter.Big, ByteConverter.Little, ByteConverter.System };
+
+            using (MemoryStream stream = new MemoryStream())
+            using (BinaryStream binaryStream = new BinaryStream(stream))
+            {
+                // Prepare test data.
+
+                // Test with no arguments.
+                foreach (Boolean value in values)
+                    binaryStream.WriteBoolean(value);
+
+                // Test with different encodings.
+                foreach (BooleanCoding encoding in encodings)
+                    foreach (Boolean value in values)
+                        binaryStream.WriteBoolean(value, encoding);
+
+                // Test with different encodings and endianness.
+                foreach (ByteConverter endian in endianness)
+                    foreach (BooleanCoding encoding in encodings)
+                        foreach (Boolean value in values)
+                            binaryStream.WriteBoolean(value, coding: encoding, converter: endian);
+
+                // Test with different endianness.
+                foreach (ByteConverter endian in endianness)
+                    foreach (Boolean value in values)
+                        binaryStream.WriteBoolean(value, converter: endian);
+
+                // Read test data.
+
+                binaryStream.Position = 0;
+
+                // Test with no arguments.
+                foreach (Boolean value in values)
+                    Assert.AreEqual(value, binaryStream.ReadBoolean());
+
+                // Test with different encodings.
+                foreach (BooleanCoding encoding in encodings)
+                    foreach (Boolean value in values)
+                        Assert.AreEqual(value, binaryStream.ReadBoolean(encoding));
+
+                // Test with different encodings and endianness.
+                foreach (ByteConverter endian in endianness)
+                    foreach (BooleanCoding encoding in encodings)
+                        foreach (Boolean value in values)
+                            Assert.AreEqual(value, binaryStream.ReadBoolean(coding: encoding));
+
+                // Test with different endianness.
+                foreach (ByteConverter endian in endianness)
+                    foreach (Boolean value in values)
+                        Assert.AreEqual(value, binaryStream.ReadBoolean());
+
+
+                // Read test data as integers.
+                binaryStream.Position = 0;
+
+                // Test with no arguments.
+                foreach (Boolean value in values)
+                    Assert.AreEqual(value ? 1 : 0, binaryStream.Read1Byte());
+
+                // Test with different encodings.
+                foreach (BooleanCoding encoding in encodings)
+                {
+                    if (encoding == BooleanCoding.Byte)
+                    {
+                        foreach (Boolean value in values)
+                            Assert.AreEqual(value ? 1 : 0, binaryStream.Read1Byte());
+                    }
+                    else if (encoding == BooleanCoding.Word)
+                    {
+                        foreach (Boolean value in values)
+                            Assert.AreEqual(value ? 1 : 0, binaryStream.ReadInt16());
+                    }
+                    else if (encoding == BooleanCoding.Dword)
+                    {
+                        foreach (Boolean value in values)
+                            Assert.AreEqual(value ? 1 : 0, binaryStream.ReadInt32());
+                    }
+                }
+                
+                // Test with different encodings and endianness.
+                foreach (ByteConverter endian in endianness)
+                {
+                    foreach (BooleanCoding encoding in encodings)
+                    {
+                        if (encoding == BooleanCoding.Byte)
+                        {
+                            foreach (Boolean value in values)
+                                Assert.AreEqual(value ? 1 : 0, binaryStream.Read1Byte());
+                        }
+                        else if (encoding == BooleanCoding.Word)
+                        {
+                            foreach (Boolean value in values)
+                                Assert.AreEqual(value ? 1 : 0, binaryStream.ReadInt16(endian));
+                        }
+                        else if (encoding == BooleanCoding.Dword)
+                        {
+                            foreach (Boolean value in values)
+                                Assert.AreEqual(value ? 1 : 0, binaryStream.ReadInt32(endian));
+                        }
+                    }
+                }
+
+                // Test with different endianness.
+                foreach (Boolean value in values)
+                    Assert.AreEqual(value ? 1 : 0, binaryStream.Read1Byte());
+
+
+                // Read test data all at once. 
+
+                binaryStream.Position = 0;
+
+                // Test with no arguments.
+                CollectionAssert.AreEqual(values, binaryStream.ReadBooleans(values.Length));
+
+                // Test with different encodings.
+                foreach (BooleanCoding encoding in encodings)
+                    CollectionAssert.AreEqual(values, binaryStream.ReadBooleans(values.Length, encoding));
+
+                // Test with different encodings and endianness.
+                foreach (ByteConverter endian in endianness)
+                    foreach (BooleanCoding encoding in encodings)
+                        CollectionAssert.AreEqual(values, binaryStream.ReadBooleans(values.Length, encoding));
+
+                // Test with different endianness.
+                CollectionAssert.AreEqual(values, binaryStream.ReadBooleans(values.Length));
+            }
+        }
+    }
+}


### PR DESCRIPTION
A series of tests that check reading and writing booleans with no arguments, with different encodings, different endianness, and both. In addition to checks for reading the values all at once. This test passes.


Important Note: Although this unit test passes, I do have some concerns about this pull request. While adding this unit test I ran into some issues with reading the booleans as integers/bytes. This unit test first tests booleans written without additional arguments. Then it tests writing booleans with different encodings. Then with different encodings and endianness. And finally with different endianness.

When the order of the test for different endianness is swapped with the test that tests both different encodings and endianness at the same time, then the unit test will not pass. 

These two tests pass individually, but if they are together, it will only work if the one that checks both endianness and encodings together is first.

This was very strange behavior. I am not yet sure if it is the result of a bug or an issue in my test logic. I decided to mention it here in case it is a sign of some unintended behavior.