### PR TITLE
Added Binary Stream Enum ReadWrite Unit Test

### DIFF
--- a/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsEnum.cs
+++ b/src/Syroot.BinaryData.UnitTest/BinaryStreamTestsEnum.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Syroot.BinaryData.UnitTest
+{
+    [TestClass]
+    public class BinaryStreamTestsEnum
+    {
+        // ---- METHODS (PUBLIC) ---------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void ReadWriteEnum()
+        {
+            Chicken[] values = new Chicken[] 
+            {
+                Chicken.RhodeIslandRed,
+                Chicken.Silkie,
+                Chicken.JerseyGiant,
+                Chicken.Leghorn,
+                Chicken.GoldenPolish,
+                Chicken.Brahma,
+                Chicken.PlymouthRock,
+                0
+            };
+
+            ByteConverter[] endianness = new ByteConverter[] 
+            {
+                ByteConverter.Big,
+                ByteConverter.Little,
+                ByteConverter.System
+            };
+
+            using (BinaryStream binaryStreamDefault = new BinaryStream(new MemoryStream()))
+            using (BinaryStream binaryStreamLittle = new BinaryStream(new MemoryStream(), ByteConverter.Little))
+            using (BinaryStream binaryStreamBig = new BinaryStream(new MemoryStream(), ByteConverter.Big))
+            using (BinaryStream binaryStreamSystem = new BinaryStream(new MemoryStream(), ByteConverter.System))
+            {
+                // Collect streams with different initializations to test.
+                BinaryStream[] binaryStreams = new BinaryStream[] { binaryStreamDefault, binaryStreamLittle, binaryStreamBig, binaryStreamSystem };
+
+                foreach (BinaryStream binaryStream in binaryStreams)
+                {
+
+                    // Prepare test data.
+
+                    foreach (Chicken value in values)
+                        binaryStream.WriteEnum(value, true);
+
+                    foreach (ByteConverter endian in endianness)
+                        foreach (Chicken value in values)
+                            binaryStream.WriteEnum(value, true, endian);
+
+                    // Read test data.
+                    binaryStream.Position = 0;
+
+                    foreach (Chicken value in values)
+                        Assert.AreEqual(value, binaryStream.ReadEnum<Chicken>(true));
+
+                    foreach (ByteConverter endian in endianness)
+                        foreach (Chicken value in values)
+                            Assert.AreEqual(value, binaryStream.ReadEnum<Chicken>(true, endian));
+
+                    // Read test data as integers.
+
+                    binaryStream.Position = 0;
+
+                    foreach (Chicken value in values)
+                        Assert.AreEqual(value, (Chicken)binaryStream.ReadUInt16());
+
+                    foreach (ByteConverter endian in endianness)
+                        foreach (Chicken value in values)
+                            Assert.AreEqual(value, (Chicken)binaryStream.ReadUInt16(endian));
+
+                    // Read test data all at once. 
+
+                    binaryStream.Position = 0;
+
+                    CollectionAssert.AreEqual(values, binaryStream.ReadEnums<Chicken>(values.Length, true));
+
+                    foreach (ByteConverter endian in endianness)
+                        CollectionAssert.AreEqual(values, binaryStream.ReadEnums<Chicken>(values.Length, true, endian));
+                }
+            }
+        }
+
+
+        // ---- CLASSES, STRUCTS & ENUMS -------------------------------------------------------------------------------
+
+        private enum Chicken : UInt16
+        {
+            RhodeIslandRed,
+            Silkie = 1,
+            JerseyGiant = 7,
+            Leghorn = 10,
+            GoldenPolish = 147,
+            Brahma,
+            PlymouthRock = UInt16.MaxValue
+        }
+    }
+}


### PR DESCRIPTION
-Added ReadWrite test for the Binary Stream with Enum values.

This test passes on my end. I have done something slightly different with this one than the previous ones. Previously I had tested binary streams with different initialization by copying the whole test with a new stream.

This time I have created multiple binary streams, put them in a collection, and looped the test to run for each binary stream. This has simplified testing several binary streams. Otherwise the different binary streams can be split into different test methods.